### PR TITLE
always use top_k call

### DIFF
--- a/Utils/MultiGather.py
+++ b/Utils/MultiGather.py
@@ -27,7 +27,7 @@ def gatherTopK(t, k, others=[], sorted=False):
     res=[]
     with tf.name_scope("gather_top_k"):
         isMoreThanK = tf.shape(t)[-1]>k
-        values, indices = tf.cond(isMoreThanK, lambda: tf.nn.top_k(t, k=k, sorted=sorted), lambda: tf.tuple([t, tf.zeros((0,1), tf.int32)]))
+        values, indices = tf.nn.top_k(t, k=k, sorted=sorted)
         indices = tf.reshape(indices, [-1,1])
         res.append(values)
 


### PR DESCRIPTION
Fixes the error:

```
"Incompatible return types of true_fn and false_fn: {}".format(e))
TypeError: Incompatible return types of true_fn and false_fn: The two structures don't have the same sequence type. First structure has type <class 'tensorflow.python.ops.gen_nn_ops.TopKV2'>, while second structure has type <class 'list'>.
```